### PR TITLE
add trigger on push

### DIFF
--- a/.github/workflows/remote_copy_file.yml
+++ b/.github/workflows/remote_copy_file.yml
@@ -4,7 +4,9 @@ name: Copy resume.pdf to nikronic.github.io
 
 # Controls when the workflow will run
 on:
-  # Triggers the workflow on pull request events but only for the "nikronic.com" branch
+  # Triggers the workflow on push or pull request events but only for the "nikronic.com" branch
+  push:
+    branches: [ nikronic.com ]
   pull_request:
     branches: [ nikronic.com ]
 


### PR DESCRIPTION
Just add trigger on push. Apparently, if only enabled on `merge`, then only runs workflow when pull request is made, not when merged into target branch. The reason could be that the merge operation is in fact a push operation. So, it is needed to enable triggers fir push operation.