### PR TITLE
now push event only triggers the workflow

### DIFF
--- a/.github/workflows/remote_copy_file.yml
+++ b/.github/workflows/remote_copy_file.yml
@@ -7,8 +7,6 @@ on:
   # Triggers the workflow on push or pull request events but only for the "nikronic.com" branch
   push:
     branches: [ nikronic.com ]
-  pull_request:
-    branches: [ nikronic.com ]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
Well, when a PR hasn't merged yet which means each commit in that requested PR is going to trigger the workflow. But since our workflow is going to actually update an outside repo (`nikronic.github.io/master` branch), it is not rational.

So, we only care about actually merged and reviewed PR. This means only push events on the `nikronic.com` branch.